### PR TITLE
Replace Slack invite link

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@ title: About The Podcast
 {% capture about-content %}
 <p>Linguistics After Dark is a podcast where three linguists (and sometimes other people) answer your burning questions about language, linguistics, and whatever else you need advice about. We have three rules: any question is fair game, there's no research allowed, and if we can't answer, we have to drink.</p>
 <p>It's a little like CarTalk for language: call us if your language is making a funny noise, and we'll get to the bottom of it, with a lot of rowdy discussion and bad nerdy jokes along the way. At the beginning of every show, we introduce a new linguistics term, and there's even a puzzler at the end!</p>
-<p>If you want to discuss episodes and get involved with the LxAD community, you can make an account on <a href="http://slackin.emfozzingenterprises.org/">The Crossings Slack</a> and find us in the #linguistics channel!</p>
+<p>If you want to discuss episodes and get involved with the LxAD community, you can make an account on <a href="https://join.slack.com/t/the-crossings/shared_invite/zt-1ido12bn6-f2ewbp4yx1g_lIIGGDDzYA">The Crossings Slack</a> and find us in the #linguistics channel!</p>
 {% endcapture %}
 
 {% assign hosts-title="Meet the Hosts:"%}


### PR DESCRIPTION
The current link will not work past EOY. This new link should work indefinitely, until 400 users have used it.